### PR TITLE
fixed timeout inconsistencys  with diag pulse/select menu

### DIFF
--- a/Controller/pulse_select_mode.c
+++ b/Controller/pulse_select_mode.c
@@ -446,7 +446,19 @@ void pulse_select_pressedBOT(Controller_Model *Model){
 
 	diag_pulse_init(&dp,0, pselect_model.page);
 
-	diag_pulse(&dp);
+	if (diag_pulse(&dp)){
+		// diag pulse exited due to critical battery or reaching an inactivity timeout 
+		// any changed options are not sent to the server 
+		// --> exiting to main window 
+		LCD_Cls(BGC);
+		
+		Controller_Model_options*  opt_model = get_option_model();
+		opt_model->options_changed= false;
+		option_exit((Controller_Model*) opt_model, 0);
+		
+		return;
+		
+	}
 
 	pulse_select_drawPage();
 
@@ -468,9 +480,13 @@ void pulse_select_pre_Switch_case_Tasks(Controller_Model *Model){
 	if(!set_timeout(0,TIMER_3, USE_TIMER))
 	{
 		LCD_Cls(BGC);
-		paint_diag(1);
+		
+		Controller_Model_options*  opt_model = get_option_model();
+		opt_model->options_changed= false;
+		option_exit((Controller_Model*) opt_model, 0);
+		
 
-		Model->mode->next = ex_diagnostic;
+		
 		
 	}
 }

--- a/diag_pulse.c
+++ b/diag_pulse.c
@@ -928,7 +928,7 @@ void diag_send_r_calibration(diag_pulseType *dp){
 
 
 
-void diag_pulse(diag_pulseType *dp){
+uint8_t diag_pulse(diag_pulseType *dp){
 
 	diag_pulse_coords(dp); // draw Window
 	
@@ -1010,8 +1010,23 @@ void diag_pulse(diag_pulseType *dp){
 
 	while(back)
 	{
+		int key = keyhit_block();
+		
+		if (key != 0)
+		{
+			set_timeout(0, TIMER_3, RESET_TIMER);
+			set_timeout(OPT_TIMEOUT_TIME, TIMER_3, USE_TIMER);
+		}
 
-		switch(keyhit_block())
+		if(!set_timeout(0,TIMER_3, USE_TIMER))  //exit options  if no key was pressed
+		{
+			back = false;
+			_delay_ms(100);
+			not_ready_for_new_key();
+			return 1;
+		}
+
+		switch(key)
 		{
 
 			case KEY_LEFT_S7:
@@ -1127,7 +1142,7 @@ void diag_pulse(diag_pulseType *dp){
 			back = false;
 			_delay_ms(100);
 			not_ready_for_new_key();
-			return;
+			return 0;
 			break;
 
 			case  KEY_DOWN_S9:
@@ -1182,13 +1197,13 @@ void diag_pulse(diag_pulseType *dp){
 			back = false;
 			_delay_ms(100);
 			not_ready_for_new_key();
-			return;
+			return 1;
 
 		}
 	}
 
 
-
+	return 0;
 }
 
 

--- a/diag_pulse.h
+++ b/diag_pulse.h
@@ -36,7 +36,7 @@ void diag_pulse_plot_seg(uint16_t index,diag_pulseType *dp);
 void diag_pulse_Measure(diag_pulseType *dp);
 void diag_pulse_move_cursor(diag_pulseType *dp,int8_t direction);
 void diag_pulse_send(diag_pulseType *dp);
-void diag_pulse(diag_pulseType *dp);
+uint8_t diag_pulse(diag_pulseType *dp);
 void diag_send_sub_packets(diag_pulseType *dp,uint8_t Message_code,uint8_t n_Packets);
 void diag_send_r_calibration(diag_pulseType *dp);
 


### PR DESCRIPTION
- diag pulse has a tiimeout now (~60s) --> exits directly to main (any changed opotions are not saved)
- pulse select --> exits directly to main (any changed opotions are not saved)
- diag mode has no timeout (but critical batt triggers a shutdown)


closes #16 
closes #20 
